### PR TITLE
Support request filters

### DIFF
--- a/iex-trading-api/src/main/java/pl/zankowski/iextrading/api/filter/RequestFilter.java
+++ b/iex-trading-api/src/main/java/pl/zankowski/iextrading/api/filter/RequestFilter.java
@@ -1,0 +1,44 @@
+package pl.zankowski.iextrading.api.filter;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @author Wojciech Zankowski
+ */
+public class RequestFilter {
+
+	public static final String FILTER_DELIMITER = ",";
+	public static final String FILTER_QUERY_NAME = "filter";
+
+	private final String columnList;
+
+	public RequestFilter(String columnList) {
+		this.columnList = columnList;
+	}
+
+	public String getColumnList() {
+		return columnList;
+	}
+
+	public static RequestFilter.Builder builder() {
+		return new RequestFilter.Builder();
+	}
+
+	public static class Builder {
+
+		private final Set<String> columns = new HashSet<>();
+
+		public Builder with(String column) {
+			this.columns.add(column);
+			return this;
+		}
+
+		public RequestFilter build() {
+			return new RequestFilter(columns.stream().collect(Collectors.joining(FILTER_DELIMITER)));
+		}
+
+	}
+
+}

--- a/iex-trading-rest-client/src/main/java/pl/zankowski/iextrading/rest/client/endpoint/market/MarketEndpoint.java
+++ b/iex-trading-rest-client/src/main/java/pl/zankowski/iextrading/rest/client/endpoint/market/MarketEndpoint.java
@@ -1,5 +1,6 @@
 package pl.zankowski.iextrading.rest.client.endpoint.market;
 
+import pl.zankowski.iextrading.api.filter.RequestFilter;
 import pl.zankowski.iextrading.api.market.MarketVolume;
 import pl.zankowski.iextrading.rest.client.endpoint.Endpoint;
 
@@ -9,5 +10,7 @@ import pl.zankowski.iextrading.rest.client.endpoint.Endpoint;
 public interface MarketEndpoint extends Endpoint {
 
     MarketVolume[] requestMarketVolume();
+
+    MarketVolume[] requestMarketVolume(RequestFilter requestFilter);
 
 }

--- a/iex-trading-rest-client/src/main/java/pl/zankowski/iextrading/rest/client/endpoint/market/MarketEndpointImpl.java
+++ b/iex-trading-rest-client/src/main/java/pl/zankowski/iextrading/rest/client/endpoint/market/MarketEndpointImpl.java
@@ -1,5 +1,6 @@
 package pl.zankowski.iextrading.rest.client.endpoint.market;
 
+import pl.zankowski.iextrading.api.filter.RequestFilter;
 import pl.zankowski.iextrading.api.market.MarketVolume;
 
 import javax.ws.rs.client.Client;
@@ -7,7 +8,9 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
 
+import static pl.zankowski.iextrading.api.filter.RequestFilter.FILTER_QUERY_NAME;
 import static pl.zankowski.iextrading.rest.client.util.PathUtil.appendPaths;
+import static pl.zankowski.iextrading.rest.client.util.PathUtil.appendQuery;
 
 /**
  * @author Wojciech Zankowski
@@ -28,6 +31,14 @@ public class MarketEndpointImpl implements MarketEndpoint {
     public MarketVolume[] requestMarketVolume() {
         WebTarget webTarget = restClient.target(baseApiUrl);
         webTarget = appendPaths(webTarget, MARKET_PATH);
+        return webTarget.request(MediaType.APPLICATION_JSON).get(MarketVolume[].class);
+    }
+
+    @Override
+    public MarketVolume[] requestMarketVolume(RequestFilter requestFilter) {
+        WebTarget webTarget = restClient.target(baseApiUrl);
+        webTarget = appendPaths(webTarget, MARKET_PATH);
+        webTarget = appendQuery(webTarget, FILTER_QUERY_NAME, requestFilter.getColumnList());
         return webTarget.request(MediaType.APPLICATION_JSON).get(MarketVolume[].class);
     }
 

--- a/iex-trading-rest-client/src/main/java/pl/zankowski/iextrading/rest/client/endpoint/stats/StatsEndpoint.java
+++ b/iex-trading-rest-client/src/main/java/pl/zankowski/iextrading/rest/client/endpoint/stats/StatsEndpoint.java
@@ -1,5 +1,6 @@
 package pl.zankowski.iextrading.rest.client.endpoint.stats;
 
+import pl.zankowski.iextrading.api.filter.RequestFilter;
 import pl.zankowski.iextrading.api.stats.HistoricalDailyStats;
 import pl.zankowski.iextrading.api.stats.HistoricalStats;
 import pl.zankowski.iextrading.api.stats.IntradayStats;
@@ -17,20 +18,38 @@ public interface StatsEndpoint extends Endpoint {
 
     IntradayStats requestIntradayStats();
 
+    IntradayStats requestIntradayStats(RequestFilter requestFilter);
+
     RecentStats[] requestRecentStat();
+
+    RecentStats[] requestRecentStat(RequestFilter requestFilter);
 
     RecordsStats requestRecordsStat();
 
+    RecordsStats requestRecordsStat(RequestFilter requestFilter);
+
     HistoricalStats[] requestHistoricalStats();
+
+    HistoricalStats[] requestHistoricalStats(RequestFilter requestFilter);
 
     HistoricalStats[] requestHistoricalStats(YearMonth date);
 
+    HistoricalStats[] requestHistoricalStats(RequestFilter requestFilter, YearMonth date);
+
     HistoricalDailyStats[] requestHistoricalDailyStats();
+
+    HistoricalDailyStats[] requestHistoricalDailyStats(RequestFilter requestFilter);
 
     HistoricalDailyStats[] requestHistoricalDailyStats(YearMonth date);
 
+    HistoricalDailyStats[] requestHistoricalDailyStats(RequestFilter requestFilter, YearMonth date);
+
     HistoricalDailyStats[] requestHistoricalDailyStats(LocalDate date);
 
+    HistoricalDailyStats[] requestHistoricalDailyStats(RequestFilter requestFilter, LocalDate date);
+
     HistoricalDailyStats[] requestHistoricalDailyStats(int last);
+
+    HistoricalDailyStats[] requestHistoricalDailyStats(RequestFilter requestFilter, int last);
 
 }

--- a/iex-trading-rest-client/src/main/java/pl/zankowski/iextrading/rest/client/endpoint/stats/StatsEndpointImpl.java
+++ b/iex-trading-rest-client/src/main/java/pl/zankowski/iextrading/rest/client/endpoint/stats/StatsEndpointImpl.java
@@ -1,5 +1,6 @@
 package pl.zankowski.iextrading.rest.client.endpoint.stats;
 
+import pl.zankowski.iextrading.api.filter.RequestFilter;
 import pl.zankowski.iextrading.api.stats.HistoricalDailyStats;
 import pl.zankowski.iextrading.api.stats.HistoricalStats;
 import pl.zankowski.iextrading.api.stats.IntradayStats;
@@ -14,7 +15,9 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 
+import static pl.zankowski.iextrading.api.filter.RequestFilter.FILTER_QUERY_NAME;
 import static pl.zankowski.iextrading.rest.client.util.PathUtil.appendPaths;
+import static pl.zankowski.iextrading.rest.client.util.PathUtil.appendQuery;
 
 /**
  * @author Wojciech Zankowski
@@ -52,9 +55,25 @@ public class StatsEndpointImpl implements StatsEndpoint {
     }
 
     @Override
+    public IntradayStats requestIntradayStats(RequestFilter requestFilter) {
+        WebTarget webTarget = restClient.target(baseApiUrl);
+        webTarget = appendPaths(webTarget, STATS_PATH, INTRADAY_PATH);
+        webTarget = appendQuery(webTarget, FILTER_QUERY_NAME, requestFilter.getColumnList());
+        return webTarget.request(MediaType.APPLICATION_JSON).get(IntradayStats.class);
+    }
+
+    @Override
     public RecentStats[] requestRecentStat() {
         WebTarget webTarget = restClient.target(baseApiUrl);
         webTarget = appendPaths(webTarget, STATS_PATH, RECENT_PATH);
+        return webTarget.request(MediaType.APPLICATION_JSON).get(RecentStats[].class);
+    }
+
+    @Override
+    public RecentStats[] requestRecentStat(RequestFilter requestFilter) {
+        WebTarget webTarget = restClient.target(baseApiUrl);
+        webTarget = appendPaths(webTarget, STATS_PATH, RECENT_PATH);
+        webTarget = appendQuery(webTarget, FILTER_QUERY_NAME, requestFilter.getColumnList());
         return webTarget.request(MediaType.APPLICATION_JSON).get(RecentStats[].class);
     }
 
@@ -66,9 +85,25 @@ public class StatsEndpointImpl implements StatsEndpoint {
     }
 
     @Override
+    public RecordsStats requestRecordsStat(RequestFilter requestFilter) {
+        WebTarget webTarget = restClient.target(baseApiUrl);
+        webTarget = appendPaths(webTarget, STATS_PATH, RECORDS_PATH);
+        webTarget = appendQuery(webTarget, FILTER_QUERY_NAME, requestFilter.getColumnList());
+        return webTarget.request(MediaType.APPLICATION_JSON).get(RecordsStats.class);
+    }
+
+    @Override
     public HistoricalStats[] requestHistoricalStats() {
         WebTarget webTarget = restClient.target(baseApiUrl);
         webTarget = appendPaths(webTarget, STATS_PATH, HISTORICAL_PATH);
+        return webTarget.request(MediaType.APPLICATION_JSON).get(HistoricalStats[].class);
+    }
+
+    @Override
+    public HistoricalStats[] requestHistoricalStats(RequestFilter requestFilter) {
+        WebTarget webTarget = restClient.target(baseApiUrl);
+        webTarget = appendPaths(webTarget, STATS_PATH, HISTORICAL_PATH);
+        webTarget = appendQuery(webTarget, FILTER_QUERY_NAME, requestFilter.getColumnList());
         return webTarget.request(MediaType.APPLICATION_JSON).get(HistoricalStats[].class);
     }
 
@@ -81,9 +116,26 @@ public class StatsEndpointImpl implements StatsEndpoint {
     }
 
     @Override
+    public HistoricalStats[] requestHistoricalStats(RequestFilter requestFilter, YearMonth date) {
+        WebTarget webTarget = restClient.target(baseApiUrl);
+        webTarget = appendPaths(webTarget, STATS_PATH, HISTORICAL_PATH);
+        webTarget = webTarget.queryParam(HISTORICAL_DATE_PARAM, YEARMONTH_PARAM_FORMATTER.format(date));
+        webTarget = appendQuery(webTarget, FILTER_QUERY_NAME, requestFilter.getColumnList());
+        return webTarget.request(MediaType.APPLICATION_JSON).get(HistoricalStats[].class);
+    }
+
+    @Override
     public HistoricalDailyStats[] requestHistoricalDailyStats() {
         WebTarget webTarget = restClient.target(baseApiUrl);
         webTarget = appendPaths(webTarget, STATS_PATH, HISTORICAL_PATH, HISTORICAL_DAILY_PATH);
+        return webTarget.request(MediaType.APPLICATION_JSON).get(HistoricalDailyStats[].class);
+    }
+
+    @Override
+    public HistoricalDailyStats[] requestHistoricalDailyStats(RequestFilter requestFilter) {
+        WebTarget webTarget = restClient.target(baseApiUrl);
+        webTarget = appendPaths(webTarget, STATS_PATH, HISTORICAL_PATH, HISTORICAL_DAILY_PATH);
+        webTarget = appendQuery(webTarget, FILTER_QUERY_NAME, requestFilter.getColumnList());
         return webTarget.request(MediaType.APPLICATION_JSON).get(HistoricalDailyStats[].class);
     }
 
@@ -96,6 +148,15 @@ public class StatsEndpointImpl implements StatsEndpoint {
     }
 
     @Override
+    public HistoricalDailyStats[] requestHistoricalDailyStats(RequestFilter requestFilter, YearMonth date) {
+        WebTarget webTarget = restClient.target(baseApiUrl);
+        webTarget = appendPaths(webTarget, STATS_PATH, HISTORICAL_PATH, HISTORICAL_DAILY_PATH);
+        webTarget = webTarget.queryParam(HISTORICAL_DAILY_DATE_PARAM, YEARMONTH_PARAM_FORMATTER.format(date));
+        webTarget = appendQuery(webTarget, FILTER_QUERY_NAME, requestFilter.getColumnList());
+        return webTarget.request(MediaType.APPLICATION_JSON).get(HistoricalDailyStats[].class);
+    }
+
+    @Override
     public HistoricalDailyStats[] requestHistoricalDailyStats(LocalDate date) {
         WebTarget webTarget = restClient.target(baseApiUrl);
         webTarget = appendPaths(webTarget, STATS_PATH, HISTORICAL_PATH, HISTORICAL_DAILY_PATH);
@@ -104,10 +165,28 @@ public class StatsEndpointImpl implements StatsEndpoint {
     }
 
     @Override
+    public HistoricalDailyStats[] requestHistoricalDailyStats(RequestFilter requestFilter, LocalDate date) {
+        WebTarget webTarget = restClient.target(baseApiUrl);
+        webTarget = appendPaths(webTarget, STATS_PATH, HISTORICAL_PATH, HISTORICAL_DAILY_PATH);
+        webTarget = webTarget.queryParam(HISTORICAL_DAILY_DATE_PARAM, DATE_PARAM_FORMATTER.format(date));
+        webTarget = appendQuery(webTarget, FILTER_QUERY_NAME, requestFilter.getColumnList());
+        return webTarget.request(MediaType.APPLICATION_JSON).get(HistoricalDailyStats[].class);
+    }
+
+    @Override
     public HistoricalDailyStats[] requestHistoricalDailyStats(int last) {
         WebTarget webTarget = restClient.target(baseApiUrl);
         webTarget = appendPaths(webTarget, STATS_PATH, HISTORICAL_PATH, HISTORICAL_DAILY_PATH);
         webTarget = webTarget.queryParam(HISTORICAL_DAILY_LAST_PARAM, last);
+        return webTarget.request(MediaType.APPLICATION_JSON).get(HistoricalDailyStats[].class);
+    }
+
+    @Override
+    public HistoricalDailyStats[] requestHistoricalDailyStats(RequestFilter requestFilter, int last) {
+        WebTarget webTarget = restClient.target(baseApiUrl);
+        webTarget = appendPaths(webTarget, STATS_PATH, HISTORICAL_PATH, HISTORICAL_DAILY_PATH);
+        webTarget = webTarget.queryParam(HISTORICAL_DAILY_LAST_PARAM, last);
+        webTarget = appendQuery(webTarget, FILTER_QUERY_NAME, requestFilter.getColumnList());
         return webTarget.request(MediaType.APPLICATION_JSON).get(HistoricalDailyStats[].class);
     }
 

--- a/iex-trading-rest-client/src/main/java/pl/zankowski/iextrading/rest/client/endpoint/tops/TOPSEndpoint.java
+++ b/iex-trading-rest-client/src/main/java/pl/zankowski/iextrading/rest/client/endpoint/tops/TOPSEndpoint.java
@@ -1,5 +1,6 @@
 package pl.zankowski.iextrading.rest.client.endpoint.tops;
 
+import pl.zankowski.iextrading.api.filter.RequestFilter;
 import pl.zankowski.iextrading.api.tops.LastTrade;
 import pl.zankowski.iextrading.api.tops.TOPS;
 import pl.zankowski.iextrading.rest.client.endpoint.Endpoint;
@@ -11,6 +12,10 @@ public interface TOPSEndpoint extends Endpoint {
 
     TOPS[] requestTOPS(String... symbols);
 
+    TOPS[] requestTOPS(RequestFilter requestFilter, String... symbols);
+
     LastTrade[] requestLastTrades(String... symbols);
+
+    LastTrade[] requestLastTrades(RequestFilter requestFilter, String... symbols);
 
 }

--- a/iex-trading-rest-client/src/main/java/pl/zankowski/iextrading/rest/client/endpoint/tops/TOPSEndpointImpl.java
+++ b/iex-trading-rest-client/src/main/java/pl/zankowski/iextrading/rest/client/endpoint/tops/TOPSEndpointImpl.java
@@ -1,5 +1,6 @@
 package pl.zankowski.iextrading.rest.client.endpoint.tops;
 
+import pl.zankowski.iextrading.api.filter.RequestFilter;
 import pl.zankowski.iextrading.api.tops.LastTrade;
 import pl.zankowski.iextrading.api.tops.TOPS;
 
@@ -10,6 +11,7 @@ import javax.ws.rs.core.UriBuilder;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import static pl.zankowski.iextrading.api.filter.RequestFilter.FILTER_QUERY_NAME;
 import static pl.zankowski.iextrading.rest.client.util.PathUtil.appendPaths;
 import static pl.zankowski.iextrading.rest.client.util.PathUtil.appendQuery;
 
@@ -41,10 +43,28 @@ public class TOPSEndpointImpl implements TOPSEndpoint {
     }
 
     @Override
+    public TOPS[] requestTOPS(final RequestFilter requestFilter, final String... symbols) {
+        WebTarget webTarget = restClient.target(baseApiUrl);
+        webTarget = appendPaths(webTarget, TOPS_PATH);
+        webTarget = appendSymbolQuery(webTarget, symbols);
+        webTarget = appendQuery(webTarget, FILTER_QUERY_NAME, requestFilter.getColumnList());
+        return webTarget.request(MediaType.APPLICATION_JSON).get(TOPS[].class);
+    }
+
+    @Override
     public LastTrade[] requestLastTrades(final String... symbols) {
         WebTarget webTarget = restClient.target(baseApiUrl);
         webTarget = appendPaths(webTarget, TOPS_PATH, LAST_TRADE_PATH);
         webTarget = appendSymbolQuery(webTarget, symbols);
+        return webTarget.request(MediaType.APPLICATION_JSON).get(LastTrade[].class);
+    }
+
+    @Override
+    public LastTrade[] requestLastTrades(final RequestFilter requestFilter, final String... symbols) {
+        WebTarget webTarget = restClient.target(baseApiUrl);
+        webTarget = appendPaths(webTarget, TOPS_PATH, LAST_TRADE_PATH);
+        webTarget = appendSymbolQuery(webTarget, symbols);
+        webTarget = appendQuery(webTarget, FILTER_QUERY_NAME, requestFilter.getColumnList());
         return webTarget.request(MediaType.APPLICATION_JSON).get(LastTrade[].class);
     }
 

--- a/iex-trading-samples/src/main/java/pl/zankowski/iextrading/samples/MarketExample.java
+++ b/iex-trading-samples/src/main/java/pl/zankowski/iextrading/samples/MarketExample.java
@@ -1,5 +1,6 @@
 package pl.zankowski.iextrading.samples;
 
+import pl.zankowski.iextrading.api.filter.RequestFilter;
 import pl.zankowski.iextrading.api.market.MarketVolume;
 import pl.zankowski.iextrading.rest.client.IEXTradingClient;
 
@@ -14,10 +15,20 @@ public class MarketExample {
         IEXTradingClient iexTradingClient = IEXTradingClient.create();
 
         requestMarketsVolume(iexTradingClient);
+        requestMarketsVolumeWithRequestFilter(iexTradingClient);
     }
 
     private static void requestMarketsVolume(IEXTradingClient iexTradingClient) {
         MarketVolume[] marketsVolume = iexTradingClient.getMarketEndpoint().requestMarketVolume();
+        Arrays.stream(marketsVolume).forEach(System.out::println);
+    }
+
+    private static void requestMarketsVolumeWithRequestFilter(IEXTradingClient iexTradingClient) {
+        RequestFilter requestFilter = RequestFilter.builder()
+                .with("mic")
+                .with("marketPercent")
+                .build();
+        MarketVolume[] marketsVolume = iexTradingClient.getMarketEndpoint().requestMarketVolume(requestFilter);
         Arrays.stream(marketsVolume).forEach(System.out::println);
     }
 

--- a/iex-trading-samples/src/main/java/pl/zankowski/iextrading/samples/StatsExample.java
+++ b/iex-trading-samples/src/main/java/pl/zankowski/iextrading/samples/StatsExample.java
@@ -1,5 +1,6 @@
 package pl.zankowski.iextrading.samples;
 
+import pl.zankowski.iextrading.api.filter.RequestFilter;
 import pl.zankowski.iextrading.api.stats.HistoricalDailyStats;
 import pl.zankowski.iextrading.api.stats.HistoricalStats;
 import pl.zankowski.iextrading.api.stats.IntradayStats;
@@ -20,20 +21,44 @@ public class StatsExample {
         IEXTradingClient iexTradingClient = IEXTradingClient.create();
 
         requestIntradayStats(iexTradingClient);
+        requestColumnFilteredIntradayStats(iexTradingClient);
+
         requestRecentStats(iexTradingClient);
+        requestColumnFilteredRecentStats(iexTradingClient);
+
         requestRecordsStat(iexTradingClient);
+        requestColumnFilteredRecordsStat(iexTradingClient);
 
         requestLastDayHistoricalStats(iexTradingClient);
-        requestFilteredHistoricalStatsByYearMonth(iexTradingClient);
+        requestColumnFilteredLastDayHistoricalStats(iexTradingClient);
+
+        requestYearMonthFilteredHistoricalStats(iexTradingClient);
+        requestYearMonthAndColumnFilteredHistoricalStats(iexTradingClient);
 
         requestLastDayHistoricalDailyStats(iexTradingClient);
-        requestFilteredHistoricalDailyStatsByYearMonth(iexTradingClient);
-        requestFilteredHistoricalDailyStatsByYearMonthDay(iexTradingClient);
+        requestColumnFilteredLastDayHistoricalDailyStats(iexTradingClient);
+
+        requestYearMonthFilteredHistoricalDailyStats(iexTradingClient);
+        requestYearMonthAndColumnFilteredHistoricalDailyStats(iexTradingClient);
+
+        requestDateFilteredHistoricalDailyStats(iexTradingClient);
+        requestDateAndColumnFilteredHistoricalDailyStats(iexTradingClient);
+
         requestLastHistoricalDailyStats(iexTradingClient);
+        requestColumnFilteredLastHistoricalDailyStats(iexTradingClient);
     }
 
     private static void requestIntradayStats(IEXTradingClient iexTradingClient) {
         IntradayStats intradayStats = iexTradingClient.getStatsEndpoint().requestIntradayStats();
+        System.out.println(intradayStats);
+    }
+
+    private static void requestColumnFilteredIntradayStats(IEXTradingClient iexTradingClient) {
+        RequestFilter requestFilter = RequestFilter.builder()
+                .with("volume")
+                .with("marketShare")
+                .build();
+        IntradayStats intradayStats = iexTradingClient.getStatsEndpoint().requestIntradayStats(requestFilter);
         System.out.println(intradayStats);
     }
 
@@ -42,8 +67,26 @@ public class StatsExample {
         Arrays.stream(recentStats).forEach(System.out::println);
     }
 
+    private static void requestColumnFilteredRecentStats(IEXTradingClient iexTradingClient) {
+        RequestFilter requestFilter = RequestFilter.builder()
+                .with("volume")
+                .with("routedVolume")
+                .build();
+        RecentStats[] recentStats = iexTradingClient.getStatsEndpoint().requestRecentStat(requestFilter);
+        Arrays.stream(recentStats).forEach(System.out::println);
+    }
+
     private static void requestRecordsStat(IEXTradingClient iexTradingClient) {
         RecordsStats recordsStat = iexTradingClient.getStatsEndpoint().requestRecordsStat();
+        System.out.println(recordsStat);
+    }
+
+    private static void requestColumnFilteredRecordsStat(IEXTradingClient iexTradingClient) {
+        RequestFilter requestFilter = RequestFilter.builder()
+                .with("volume")
+                .with("symbolsTraded")
+                .build();
+        RecordsStats recordsStat = iexTradingClient.getStatsEndpoint().requestRecordsStat(requestFilter);
         System.out.println(recordsStat);
     }
 
@@ -52,8 +95,26 @@ public class StatsExample {
         Arrays.stream(historicalStats).forEach(System.out::println);
     }
 
-    private static void requestFilteredHistoricalStatsByYearMonth(IEXTradingClient iexTradingClient) {
+    private static void requestColumnFilteredLastDayHistoricalStats(IEXTradingClient iexTradingClient) {
+        RequestFilter requestFilter = RequestFilter.builder()
+                .with("averageDailyVolume")
+                .with("largeCapPercent")
+                .build();
+        HistoricalStats[] historicalStats = iexTradingClient.getStatsEndpoint().requestHistoricalStats(requestFilter);
+        Arrays.stream(historicalStats).forEach(System.out::println);
+    }
+
+    private static void requestYearMonthFilteredHistoricalStats(IEXTradingClient iexTradingClient) {
         HistoricalStats[] historicalStats = iexTradingClient.getStatsEndpoint().requestHistoricalStats(YearMonth.of(2017, 3));
+        Arrays.stream(historicalStats).forEach(System.out::println);
+    }
+
+    private static void requestYearMonthAndColumnFilteredHistoricalStats(IEXTradingClient iexTradingClient) {
+        RequestFilter requestFilter = RequestFilter.builder()
+                .with("averageDailyVolume")
+                .with("largeCapPercent")
+                .build();
+        HistoricalStats[] historicalStats = iexTradingClient.getStatsEndpoint().requestHistoricalStats(requestFilter, YearMonth.of(2017, 3));
         Arrays.stream(historicalStats).forEach(System.out::println);
     }
 
@@ -62,18 +123,54 @@ public class StatsExample {
         Arrays.stream(historicalDailyStats).forEach(System.out::println);
     }
 
-    private static void requestFilteredHistoricalDailyStatsByYearMonth(IEXTradingClient iexTradingClient) {
+    private static void requestColumnFilteredLastDayHistoricalDailyStats(IEXTradingClient iexTradingClient) {
+        RequestFilter requestFilter = RequestFilter.builder()
+                .with("date")
+                .with("volume")
+                .build();
+        HistoricalDailyStats[] historicalDailyStats = iexTradingClient.getStatsEndpoint().requestHistoricalDailyStats(requestFilter);
+        Arrays.stream(historicalDailyStats).forEach(System.out::println);
+    }
+
+    private static void requestYearMonthFilteredHistoricalDailyStats(IEXTradingClient iexTradingClient) {
         HistoricalDailyStats[] historicalDailyStats = iexTradingClient.getStatsEndpoint().requestHistoricalDailyStats(YearMonth.of(2017,3));
         Arrays.stream(historicalDailyStats).forEach(System.out::println);
     }
 
-    private static void requestFilteredHistoricalDailyStatsByYearMonthDay(IEXTradingClient iexTradingClient) {
+    private static void requestYearMonthAndColumnFilteredHistoricalDailyStats(IEXTradingClient iexTradingClient) {
+        RequestFilter requestFilter = RequestFilter.builder()
+                .with("date")
+                .with("volume")
+                .build();
+        HistoricalDailyStats[] historicalDailyStats = iexTradingClient.getStatsEndpoint().requestHistoricalDailyStats(requestFilter, YearMonth.of(2017,3));
+        Arrays.stream(historicalDailyStats).forEach(System.out::println);
+    }
+
+    private static void requestDateFilteredHistoricalDailyStats(IEXTradingClient iexTradingClient) {
         HistoricalDailyStats[] historicalDailyStats = iexTradingClient.getStatsEndpoint().requestHistoricalDailyStats(LocalDate.of(2017, 3, 6));
+        Arrays.stream(historicalDailyStats).forEach(System.out::println);
+    }
+
+    private static void requestDateAndColumnFilteredHistoricalDailyStats(IEXTradingClient iexTradingClient) {
+        RequestFilter requestFilter = RequestFilter.builder()
+                .with("date")
+                .with("volume")
+                .build();
+        HistoricalDailyStats[] historicalDailyStats = iexTradingClient.getStatsEndpoint().requestHistoricalDailyStats(requestFilter, LocalDate.of(2017, 3, 6));
         Arrays.stream(historicalDailyStats).forEach(System.out::println);
     }
 
     private static void requestLastHistoricalDailyStats(IEXTradingClient iexTradingClient) {
         HistoricalDailyStats[] historicalDailyStats = iexTradingClient.getStatsEndpoint().requestHistoricalDailyStats(13);
+        Arrays.stream(historicalDailyStats).forEach(System.out::println);
+    }
+
+    private static void requestColumnFilteredLastHistoricalDailyStats(IEXTradingClient iexTradingClient) {
+        RequestFilter requestFilter = RequestFilter.builder()
+                .with("date")
+                .with("volume")
+                .build();
+        HistoricalDailyStats[] historicalDailyStats = iexTradingClient.getStatsEndpoint().requestHistoricalDailyStats(requestFilter,13);
         Arrays.stream(historicalDailyStats).forEach(System.out::println);
     }
 

--- a/iex-trading-samples/src/main/java/pl/zankowski/iextrading/samples/TOPSExample.java
+++ b/iex-trading-samples/src/main/java/pl/zankowski/iextrading/samples/TOPSExample.java
@@ -1,5 +1,6 @@
 package pl.zankowski.iextrading.samples;
 
+import pl.zankowski.iextrading.api.filter.RequestFilter;
 import pl.zankowski.iextrading.api.tops.LastTrade;
 import pl.zankowski.iextrading.api.tops.TOPS;
 import pl.zankowski.iextrading.rest.client.IEXTradingClient;
@@ -15,9 +16,16 @@ public class TOPSExample {
         IEXTradingClient iexTradingClient = IEXTradingClient.create();
 
         requestAllTOPS(iexTradingClient);
-        requestFilteredTOPS(iexTradingClient);
+        requestColumnFilteredAllTOPS(iexTradingClient);
+
+        requestSymbolFilteredTOPS(iexTradingClient);
+        requestSymbolAndColumnFilteredTOPS(iexTradingClient);
+
         requestAllLastTrades(iexTradingClient);
-        requestFilteredLastTrades(iexTradingClient);
+        requestColumnFilteredAllLastTrades(iexTradingClient);
+
+        requestSymbolFilteredLastTrades(iexTradingClient);
+        requestSymbolAndColumnFilteredLastTrades(iexTradingClient);
     }
 
     private static void requestAllTOPS(IEXTradingClient iexTradingClient) {
@@ -25,8 +33,28 @@ public class TOPSExample {
         Arrays.stream(allTOPS).forEach(System.out::println);
     }
 
-    private static void requestFilteredTOPS(IEXTradingClient iexTradingClient) {
+    private static void requestColumnFilteredAllTOPS(IEXTradingClient iexTradingClient) {
+        RequestFilter requestFilter = RequestFilter.builder()
+                .with("symbol")
+                .with("marketPercent")
+                .with("lastSaleSize")
+                .build();
+        TOPS[] allTOPS = iexTradingClient.getTopsEndpoint().requestTOPS(requestFilter);
+        Arrays.stream(allTOPS).forEach(System.out::println);
+    }
+
+    private static void requestSymbolFilteredTOPS(IEXTradingClient iexTradingClient) {
         TOPS[] filteredTOPS = iexTradingClient.getTopsEndpoint().requestTOPS("BCM", "IBM");
+        Arrays.stream(filteredTOPS).forEach(System.out::println);
+    }
+
+    private static void requestSymbolAndColumnFilteredTOPS(IEXTradingClient iexTradingClient) {
+        RequestFilter requestFilter = RequestFilter.builder()
+                .with("symbol")
+                .with("marketPercent")
+                .with("lastSaleSize")
+                .build();
+        TOPS[] filteredTOPS = iexTradingClient.getTopsEndpoint().requestTOPS(requestFilter,"BCM", "IBM");
         Arrays.stream(filteredTOPS).forEach(System.out::println);
     }
 
@@ -35,8 +63,26 @@ public class TOPSExample {
         Arrays.stream(allLastTrades).forEach(System.out::println);
     }
 
-    private static void requestFilteredLastTrades(IEXTradingClient iexTradingClient) {
+    private static void requestColumnFilteredAllLastTrades(IEXTradingClient iexTradingClient) {
+        RequestFilter requestFilter = RequestFilter.builder()
+                .with("symbol")
+                .with("price")
+                .build();
+        LastTrade[] allLastTrades = iexTradingClient.getTopsEndpoint().requestLastTrades(requestFilter);
+        Arrays.stream(allLastTrades).forEach(System.out::println);
+    }
+
+    private static void requestSymbolFilteredLastTrades(IEXTradingClient iexTradingClient) {
         LastTrade[] filteredLastTrades = iexTradingClient.getTopsEndpoint().requestLastTrades("BCM", "IBM");
+        Arrays.stream(filteredLastTrades).forEach(System.out::println);
+    }
+
+    private static void requestSymbolAndColumnFilteredLastTrades(IEXTradingClient iexTradingClient) {
+        RequestFilter requestFilter = RequestFilter.builder()
+                .with("symbol")
+                .with("price")
+                .build();
+        LastTrade[] filteredLastTrades = iexTradingClient.getTopsEndpoint().requestLastTrades(requestFilter,"BCM", "IBM");
         Arrays.stream(filteredLastTrades).forEach(System.out::println);
     }
 


### PR DESCRIPTION
All REST endpoints support a filter parameter to return a subset of data. Pass a comma-delimited list of field names to filter. Field names are case-sensitive and are found in the Reference section of each endpoint.

    Example: ?filter=symbol,volume,lastSalePrice will return only the three fields specified.
