### PR TITLE
SentimentRequestBuilder should build a single RestRequest<Sentiment>, instead of RestRequest<List<Sentiment>>

### DIFF
--- a/iextrading4j-api/src/main/java/pl/zankowski/iextrading4j/api/alternative/SentimentEvent.java
+++ b/iextrading4j-api/src/main/java/pl/zankowski/iextrading4j/api/alternative/SentimentEvent.java
@@ -1,0 +1,73 @@
+package pl.zankowski.iextrading4j.api.alternative;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+public class SentimentEvent implements Serializable {
+
+    private static final long serialVersionUID = -4716020002316419582L;
+
+    private final String symbol;
+    private final BigDecimal score;
+    private final BigDecimal sequence;
+    private final BigDecimal date;
+
+    @JsonCreator
+    public SentimentEvent(
+            @JsonProperty("symbol") final String symbol,
+            @JsonProperty("score") final BigDecimal score,
+            @JsonProperty("sequence") final BigDecimal sequence,
+            @JsonProperty("date") final BigDecimal date) {
+        this.symbol = symbol;
+        this.score = score;
+        this.sequence = sequence;
+        this.date = date;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+    
+    public BigDecimal getScore() {
+        return score;
+    }
+
+    public BigDecimal getSequence() {
+        return sequence;
+    }
+
+    public BigDecimal getDate() {
+        return date;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final SentimentEvent sentiment1 = (SentimentEvent) o;
+        return Objects.equal(symbol, sentiment1.symbol) &&
+                Objects.equal(score, sentiment1.score) &&
+                Objects.equal(sequence, sentiment1.sequence) &&
+                Objects.equal(date, sentiment1.date);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(symbol, score, sequence, date);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("symbol", symbol)
+                .add("score", score)
+                .add("sequence", sequence)
+                .add("date", date)
+                .toString();
+    }
+
+}

--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/request/alternative/SentimentRequestBuilder.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/request/alternative/SentimentRequestBuilder.java
@@ -4,14 +4,12 @@ import pl.zankowski.iextrading4j.api.alternative.Sentiment;
 import pl.zankowski.iextrading4j.client.rest.manager.RestRequest;
 import pl.zankowski.iextrading4j.client.rest.manager.RestRequestBuilder;
 import pl.zankowski.iextrading4j.client.rest.request.stocks.AbstractStocksRequestBuilder;
-
 import javax.ws.rs.core.GenericType;
 import java.time.LocalDate;
-import java.util.List;
 
 import static pl.zankowski.iextrading4j.client.rest.request.util.RequestUtil.IEX_DATE_FORMATTER;
 
-public class SentimentRequestBuilder extends AbstractStocksRequestBuilder<List<Sentiment>, SentimentRequestBuilder> {
+public class SentimentRequestBuilder extends AbstractStocksRequestBuilder<Sentiment, SentimentRequestBuilder> {
 
     private static final String TYPE_PARAM_NAME = "type";
     private static final String DATE_PARAM_NAME = "date";
@@ -30,7 +28,7 @@ public class SentimentRequestBuilder extends AbstractStocksRequestBuilder<List<S
     }
 
     @Override
-    public RestRequest<List<Sentiment>> build() {
+    public RestRequest<Sentiment> build() {
         if (date != null) {
             return requestWithDate();
         } else if (sentimentType != null) {
@@ -39,30 +37,30 @@ public class SentimentRequestBuilder extends AbstractStocksRequestBuilder<List<S
         return request();
     }
 
-    private RestRequest<List<Sentiment>> request() {
-        return RestRequestBuilder.<List<Sentiment>>builder()
+    private RestRequest<Sentiment> request() {
+        return RestRequestBuilder.<Sentiment>builder()
                 .withPath("/stock/{symbol}/sentiment")
                 .addPathParam(SYMBOL_PARAM_NAME, getSymbol()).get()
-                .withResponse(new GenericType<List<Sentiment>>() {})
+                .withResponse(new GenericType<Sentiment>() {})
                 .build();
     }
 
-    private RestRequest<List<Sentiment>> requestWithType() {
-        return RestRequestBuilder.<List<Sentiment>>builder()
+    private RestRequest<Sentiment> requestWithType() {
+        return RestRequestBuilder.<Sentiment>builder()
                 .withPath("/stock/{symbol}/sentiment/{type}")
                 .addPathParam(SYMBOL_PARAM_NAME, getSymbol())
                 .addPathParam(TYPE_PARAM_NAME, sentimentType.name().toLowerCase()).get()
-                .withResponse(new GenericType<List<Sentiment>>() {})
+                .withResponse(new GenericType<Sentiment>() {})
                 .build();
     }
 
-    private RestRequest<List<Sentiment>> requestWithDate() {
-        return RestRequestBuilder.<List<Sentiment>>builder()
+    private RestRequest<Sentiment> requestWithDate() {
+        return RestRequestBuilder.<Sentiment>builder()
                 .withPath("/stock/{symbol}/sentiment/{type}/{date}")
                 .addPathParam(SYMBOL_PARAM_NAME, getSymbol())
                 .addPathParam(TYPE_PARAM_NAME, sentimentType.name().toLowerCase())
                 .addPathParam(DATE_PARAM_NAME, IEX_DATE_FORMATTER.format(date)).get()
-                .withResponse(new GenericType<List<Sentiment>>() {})
+                .withResponse(new GenericType<Sentiment>() {})
                 .build();
     }
 

--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/sse/request/alternative/SentimentSseRequestBuilder.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/sse/request/alternative/SentimentSseRequestBuilder.java
@@ -1,20 +1,19 @@
 package pl.zankowski.iextrading4j.client.sse.request.alternative;
 
-import pl.zankowski.iextrading4j.api.alternative.Sentiment;
+import pl.zankowski.iextrading4j.api.alternative.SentimentEvent;
 import pl.zankowski.iextrading4j.client.sse.manager.SseRequest;
 import pl.zankowski.iextrading4j.client.sse.manager.SseRequestBuilder;
 import pl.zankowski.iextrading4j.client.sse.request.AbstractSymbolSseRequestBuilder;
-
 import javax.ws.rs.core.GenericType;
 import java.util.List;
 
-public class SentimentSseRequestBuilder extends AbstractSymbolSseRequestBuilder<List<Sentiment>, SentimentSseRequestBuilder> {
+public class SentimentSseRequestBuilder extends AbstractSymbolSseRequestBuilder<List<SentimentEvent>, SentimentSseRequestBuilder> {
 
     @Override
-    public SseRequest<List<Sentiment>> build() {
-        return SseRequestBuilder.<List<Sentiment>>builder()
+    public SseRequest<List<SentimentEvent>> build() {
+        return SseRequestBuilder.<List<SentimentEvent>>builder()
                 .withPath("/sentiment")
-                .withResponse(new GenericType<List<Sentiment>>() {})
+                .withResponse(new GenericType<List<SentimentEvent>>() {})
                 .addQueryParam(SYMBOL_PARAM, getSymbol())
                 .addQueryParam(NO_SNAPSHOT_PARAM, isNoSnapshot())
                 .build();

--- a/iextrading4j-client/src/test/java/pl/zankowski/iextrading4j/client/rest/request/alternative/SentimentRequestBuilderTest.java
+++ b/iextrading4j-client/src/test/java/pl/zankowski/iextrading4j/client/rest/request/alternative/SentimentRequestBuilderTest.java
@@ -20,13 +20,13 @@ public class SentimentRequestBuilderTest {
     public void shouldSuccessfullyCreateRequest() {
         final String symbol = "IBM";
 
-        final RestRequest<List<Sentiment>> request = new SentimentRequestBuilder()
+        final RestRequest<Sentiment> request = new SentimentRequestBuilder()
                 .withSymbol(symbol)
                 .build();
 
         assertThat(request.getMethodType()).isEqualTo(MethodType.GET);
         assertThat(request.getPath()).isEqualTo("/stock/{symbol}/sentiment");
-        assertThat(request.getResponseType()).isEqualTo(new GenericType<List<Sentiment>>() {});
+        assertThat(request.getResponseType()).isEqualTo(new GenericType<Sentiment>() {});
         assertThat(request.getPathParams()).containsExactly(entry("symbol", symbol));
         assertThat(request.getQueryParams()).isEmpty();
     }
@@ -35,14 +35,14 @@ public class SentimentRequestBuilderTest {
     public void shouldSuccessfullyCreateTypeRequest() {
         final String symbol = "IBM";
 
-        final RestRequest<List<Sentiment>> request = new SentimentRequestBuilder()
+        final RestRequest<Sentiment> request = new SentimentRequestBuilder()
                 .withSentimentType(SentimentType.DAILY)
                 .withSymbol(symbol)
                 .build();
 
         assertThat(request.getMethodType()).isEqualTo(MethodType.GET);
         assertThat(request.getPath()).isEqualTo("/stock/{symbol}/sentiment/{type}");
-        assertThat(request.getResponseType()).isEqualTo(new GenericType<List<Sentiment>>() {});
+        assertThat(request.getResponseType()).isEqualTo(new GenericType<Sentiment>() {});
         assertThat(request.getPathParams()).contains(entry("symbol", symbol), entry("type", "daily"));
         assertThat(request.getQueryParams()).isEmpty();
     }
@@ -51,7 +51,7 @@ public class SentimentRequestBuilderTest {
     public void shouldSuccessfullyCreateTypeAndDateRequest() {
         final String symbol = "IBM";
 
-        final RestRequest<List<Sentiment>> request = new SentimentRequestBuilder()
+        final RestRequest<Sentiment> request = new SentimentRequestBuilder()
                 .withSentimentType(SentimentType.DAILY)
                 .withDate(LocalDate.of(2019, 5, 11))
                 .withSymbol(symbol)
@@ -59,7 +59,7 @@ public class SentimentRequestBuilderTest {
 
         assertThat(request.getMethodType()).isEqualTo(MethodType.GET);
         assertThat(request.getPath()).isEqualTo("/stock/{symbol}/sentiment/{type}/{date}");
-        assertThat(request.getResponseType()).isEqualTo(new GenericType<List<Sentiment>>() {});
+        assertThat(request.getResponseType()).isEqualTo(new GenericType<Sentiment>() {});
         assertThat(request.getPathParams()).contains(entry("symbol", symbol), entry("type", "daily"),
                 entry("date", "20190511"));
         assertThat(request.getQueryParams()).isEmpty();

--- a/iextrading4j-client/src/test/java/pl/zankowski/iextrading4j/client/sse/request/alternative/SentimentSseRequestBuilderTest.java
+++ b/iextrading4j-client/src/test/java/pl/zankowski/iextrading4j/client/sse/request/alternative/SentimentSseRequestBuilderTest.java
@@ -1,7 +1,7 @@
 package pl.zankowski.iextrading4j.client.sse.request.alternative;
 
 import org.junit.Test;
-import pl.zankowski.iextrading4j.api.alternative.Sentiment;
+import pl.zankowski.iextrading4j.api.alternative.SentimentEvent;
 import pl.zankowski.iextrading4j.client.sse.manager.SseRequest;
 
 import javax.ws.rs.core.GenericType;
@@ -17,12 +17,12 @@ public class SentimentSseRequestBuilderTest {
     public void shouldSuccessfullyCreateRequest() {
         final String symbol = "IBM";
 
-        final SseRequest<List<Sentiment>> request = new SentimentSseRequestBuilder()
+        final SseRequest<List<SentimentEvent>> request = new SentimentSseRequestBuilder()
                 .withSymbol(symbol)
                 .build();
 
         assertThat(request.getPath()).isEqualTo("/sentiment");
-        assertThat(request.getResponseType()).isEqualTo(new GenericType<List<Sentiment>>() {});
+        assertThat(request.getResponseType()).isEqualTo(new GenericType<List<SentimentEvent>>() {});
         assertThat(request.getPathParams()).isEmpty();
         assertThat(request.getQueryParams()).contains(entry("nosnapshot", "false"), entry("symbols", symbol));
     }

--- a/iextrading4j-samples/src/main/java/pl/zankowski/iextrading4j/sample/iexcloud/sse/SseAlternativeSample.java
+++ b/iextrading4j-samples/src/main/java/pl/zankowski/iextrading4j/sample/iexcloud/sse/SseAlternativeSample.java
@@ -2,7 +2,7 @@ package pl.zankowski.iextrading4j.sample.iexcloud.sse;
 
 import pl.zankowski.iextrading4j.api.alternative.CryptoBookEvent;
 import pl.zankowski.iextrading4j.api.alternative.CryptoEvent;
-import pl.zankowski.iextrading4j.api.alternative.Sentiment;
+import pl.zankowski.iextrading4j.api.alternative.SentimentEvent;
 import pl.zankowski.iextrading4j.api.stocks.Quote;
 import pl.zankowski.iextrading4j.client.IEXCloudClient;
 import pl.zankowski.iextrading4j.client.IEXCloudTokenBuilder;
@@ -37,10 +37,10 @@ public class SseAlternativeSample {
         new Semaphore(0).acquire();
     }
 
-    private static final Consumer<List<Sentiment>> SENTIMENT_CONSUMER = System.out::println;
+    private static final Consumer<List<SentimentEvent>> SENTIMENT_CONSUMER = System.out::println;
 
     private void sentimentSample() {
-        final SseRequest<List<Sentiment>> request = new SentimentSseRequestBuilder()
+        final SseRequest<List<SentimentEvent>> request = new SentimentSseRequestBuilder()
                 .withSymbol("spy")
                 .build();
 


### PR DESCRIPTION
# Description

The Sentiment Rest Response will only return one sentiment response not a list: https://iexcloud.io/docs/api/#social-sentiment

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
