### PR TITLE
Update RestManager.java

### DIFF
--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
@@ -10,6 +10,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
 
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+
 import static java.util.stream.Collectors.joining;
 
 public class RestManager {
@@ -29,6 +31,7 @@ public class RestManager {
                 restClient.getRestClientMetadata().getUrl());
 
         final Invocation.Builder invocationBuilder = restClient.getClient().target(url)
+                .register(JacksonJsonProvider.class)
                 .request(MediaType.APPLICATION_JSON);
 
         Response response = null;
@@ -43,7 +46,7 @@ public class RestManager {
                     final PostEntity requestEntity = restRequest.getRequestEntity();
                     requestEntity.setToken(resolveToken(restRequest,
                             restClient.getRestClientMetadata().getToken()));
-                    response = invocationBuilder.post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON_TYPE));
+                    response = invocationBuilder.post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON));
                     break;
                 default:
                     throw new IllegalStateException("Method Type not supported.");


### PR DESCRIPTION
# Description

Added `JacksonJsonProvider.class` to explicitly declare the jackson processor for marshalling. Because without, it conflicts with other libs if they are using other providers (for example, `Json-B`) and throws marhalling exceptions.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
