### PR TITLE
Update RestManager.java

### DIFF
--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
@@ -10,6 +10,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
 
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJsonProvider;
+
 import static java.util.stream.Collectors.joining;
 
 public class RestManager {
@@ -29,6 +31,7 @@ public class RestManager {
                 restClient.getRestClientMetadata().getUrl());
 
         final Invocation.Builder invocationBuilder = restClient.getClient().target(url)
+                .register(JacksonJsonProvider.class)
                 .request(MediaType.APPLICATION_JSON);
 
         Response response = null;
@@ -43,7 +46,7 @@ public class RestManager {
                     final PostEntity requestEntity = restRequest.getRequestEntity();
                     requestEntity.setToken(resolveToken(restRequest,
                             restClient.getRestClientMetadata().getToken()));
-                    response = invocationBuilder.post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON_TYPE));
+                    response = invocationBuilder.post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON));
                     break;
                 default:
                     throw new IllegalStateException("Method Type not supported.");

--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
@@ -30,23 +30,25 @@ public class RestManager {
         final String url = createURL(restRequest, restClient.getRestClientMetadata().getToken(),
                 restClient.getRestClientMetadata().getUrl());
 
-        final Invocation.Builder invocationBuilder = restClient.getClient().target(url)
-                .request(MediaType.APPLICATION_JSON);
-
+        Invocation.Builder invocationBuilder = null;
         Response response = null;
 
         try {
 
             switch (restRequest.getMethodType()) {
                 case GET:
+                    invocationBuilder = restClient.getClient().target(url)
+                            .request(MediaType.APPLICATION_JSON);
                     response = invocationBuilder.get();
                     break;
                 case POST:
                     final PostEntity requestEntity = restRequest.getRequestEntity();
                     requestEntity.setToken(resolveToken(restRequest,
                             restClient.getRestClientMetadata().getToken()));
-                    response = invocationBuilder.register(JacksonJsonProvider.class)
-                           .post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON_TYPE));
+                    invocationBuilder = restClient.getClient().target(url)
+                            .register(JacksonJsonProvider.class)
+                            .request(MediaType.APPLICATION_JSON);
+                    response = invocationBuilder.post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON));
                     break;
                 default:
                     throw new IllegalStateException("Method Type not supported.");

--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
@@ -46,7 +46,7 @@ public class RestManager {
                     requestEntity.setToken(resolveToken(restRequest,
                             restClient.getRestClientMetadata().getToken()));
                     response = invocationBuilder.register(JacksonJsonProvider.class)
-                        .post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON));
+                           .post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON_TYPE));
                     break;
                 default:
                     throw new IllegalStateException("Method Type not supported.");

--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
@@ -31,7 +31,6 @@ public class RestManager {
                 restClient.getRestClientMetadata().getUrl());
 
         final Invocation.Builder invocationBuilder = restClient.getClient().target(url)
-                .register(JacksonJsonProvider.class)
                 .request(MediaType.APPLICATION_JSON);
 
         Response response = null;
@@ -46,7 +45,8 @@ public class RestManager {
                     final PostEntity requestEntity = restRequest.getRequestEntity();
                     requestEntity.setToken(resolveToken(restRequest,
                             restClient.getRestClientMetadata().getToken()));
-                    response = invocationBuilder.post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON));
+                    response = invocationBuilder.register(JacksonJsonProvider.class)
+                        .post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON));
                     break;
                 default:
                     throw new IllegalStateException("Method Type not supported.");

--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
@@ -46,7 +46,7 @@ public class RestManager {
                     final PostEntity requestEntity = restRequest.getRequestEntity();
                     requestEntity.setToken(resolveToken(restRequest,
                             restClient.getRestClientMetadata().getToken()));
-                    response = invocationBuilder.post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON));
+                    response = invocationBuilder.post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON_TYPE));
                     break;
                 default:
                     throw new IllegalStateException("Method Type not supported.");

--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
@@ -46,7 +46,7 @@ public class RestManager {
                     final PostEntity requestEntity = restRequest.getRequestEntity();
                     requestEntity.setToken(resolveToken(restRequest,
                             restClient.getRestClientMetadata().getToken()));
-                    response = invocationBuilder.post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON_TYPE));
+                    response = invocationBuilder.post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON));
                     break;
                 default:
                     throw new IllegalStateException("Method Type not supported.");

--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
@@ -48,7 +48,7 @@ public class RestManager {
                     invocationBuilder = restClient.getClient().target(url)
                             .register(JacksonJsonProvider.class)
                             .request(MediaType.APPLICATION_JSON);
-                    response = invocationBuilder.post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON));
+                    response = invocationBuilder.post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON_TYPE));
                     break;
                 default:
                     throw new IllegalStateException("Method Type not supported.");


### PR DESCRIPTION
# Description
Added "JacksonJsonProvider.class" to explicitly declare the jackson processor for marshalling. Because without, it conflicts with other libs if they are using other json-providers (for example, Json-B).

Fixes # (issue)
Marshalling exceptions if other providers are also on the same classpath.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)