### PR TITLE
Update RestManager.java

### DIFF
--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
@@ -5,7 +5,7 @@ import pl.zankowski.iextrading4j.api.exception.IEXTradingException;
 import pl.zankowski.iextrading4j.client.IEXCloudToken;
 
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -30,24 +30,20 @@ public class RestManager {
         final String url = createURL(restRequest, restClient.getRestClientMetadata().getToken(),
                 restClient.getRestClientMetadata().getUrl());
 
-        Invocation.Builder invocationBuilder = null;
+        final WebTarget target = restClient.getClient().target(url);
         Response response = null;
 
         try {
 
             switch (restRequest.getMethodType()) {
                 case GET:
-                    invocationBuilder = restClient.getClient().target(url)
-                            .request(MediaType.APPLICATION_JSON);
-                    response = invocationBuilder.get();
+                    response = target.request(MediaType.APPLICATION_JSON).get();
                     break;
                 case POST:
                     final PostEntity requestEntity = restRequest.getRequestEntity();
                     requestEntity.setToken(resolveToken(restRequest, restClient.getRestClientMetadata().getToken()));
-                    invocationBuilder = restClient.getClient().target(url)
-                            .register(JacksonJsonProvider.class)
-                            .request(MediaType.APPLICATION_JSON);
-                    response = invocationBuilder.post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON));
+                    response = target.register(JacksonJsonProvider.class).request(MediaType.APPLICATION_JSON)
+                              .post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON));
                     break;
                 default:
                     throw new IllegalStateException("Method Type not supported.");


### PR DESCRIPTION
# Description
Added "JacksonJsonProvider.class" to explicitly declare the jackson processor for marshalling. Because without, it conflicts with other libs if they are using other json-providers (for example, Json-B).

Fixes # (issue)
Marshalling exceptions if other providers are also on the same classpath.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)