### PR TITLE
Updating EarningsRequestBuilder to include last in url

### DIFF
--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/request/stocks/EarningsRequestBuilder.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/request/stocks/EarningsRequestBuilder.java
@@ -20,7 +20,7 @@ public class EarningsRequestBuilder extends AbstractLastStocksRequestBuilder<Ear
 
     protected RestRequest<Earnings> requestWithLast() {
         return RestRequestBuilder.<Earnings>builder()
-                .withPath("/stock/{symbol}/earnings")
+                .withPath("/stock/{symbol}/earnings/{last}")
                 .addPathParam("last", String.valueOf(last))
                 .addPathParam("symbol", getSymbol()).get()
                 .withResponse(Earnings.class)

--- a/iextrading4j-client/src/test/java/pl/zankowski/iextrading4j/client/rest/request/stocks/EarningsRequestBuilderTest.java
+++ b/iextrading4j-client/src/test/java/pl/zankowski/iextrading4j/client/rest/request/stocks/EarningsRequestBuilderTest.java
@@ -41,7 +41,7 @@ public class EarningsRequestBuilderTest {
                 .build();
 
         assertThat(request.getMethodType()).isEqualTo(MethodType.GET);
-        assertThat(request.getPath()).isEqualTo("/stock/{symbol}/earnings");
+        assertThat(request.getPath()).isEqualTo("/stock/{symbol}/earnings/{last}");
         assertThat(request.getResponseType()).isEqualTo(new GenericType<Earnings>() {});
         assertThat(request.getPathParams()).contains(entry("symbol", symbol), entry("last", String.valueOf(last)));
         assertThat(request.getQueryParams()).contains(entry("period", period.name().toLowerCase()));


### PR DESCRIPTION
# Description

Adds the "last" parameter to the request URL when requesting earnings data from IEX.

Fixes # 83

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
