### PR TITLE
Fixed issue with different mapping providers

### DIFF
--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/IEXTradingClient.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/IEXTradingClient.java
@@ -2,7 +2,6 @@ package pl.zankowski.iextrading4j.client;
 
 import com.google.common.collect.ImmutableMap;
 
-import pl.zankowski.iextrading4j.client.mapper.IEXJacksonJsonProvider;
 import pl.zankowski.iextrading4j.client.mapper.IEXTradingMapperContextResolver;
 import pl.zankowski.iextrading4j.client.properties.PropertiesReader;
 import pl.zankowski.iextrading4j.client.properties.PropertyType;

--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/IEXTradingClient.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/IEXTradingClient.java
@@ -1,6 +1,8 @@
 package pl.zankowski.iextrading4j.client;
 
 import com.google.common.collect.ImmutableMap;
+
+import pl.zankowski.iextrading4j.client.mapper.IEXJacksonJsonProvider;
 import pl.zankowski.iextrading4j.client.mapper.IEXTradingMapperContextResolver;
 import pl.zankowski.iextrading4j.client.properties.PropertiesReader;
 import pl.zankowski.iextrading4j.client.properties.PropertyType;
@@ -20,7 +22,9 @@ import pl.zankowski.iextrading4j.client.sse.manager.SseManager;
 import pl.zankowski.iextrading4j.client.sse.manager.SseRequest;
 
 import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.glassfish.jersey.jackson.JacksonFeature;
+
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -61,7 +65,7 @@ public class IEXTradingClient implements IEXApiClient, IEXCloudClient {
     }
 
     private IEXTradingClient(final IEXTradingApiVersion version, final IEXCloudToken token) {
-        final Client client = ClientBuilder.newClient();
+        final Client client = new JerseyClientBuilder().build().register(JacksonFeature.class);
         final RestClient restClient = new RestClient(client, new RestClientMetadata(
                 PropertiesReader.getInstance().getString(REST_PATHS.get(version)), token));
         final SseClient sseClient = new SseClient(client, new SseClientMetadata(

--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/rest/manager/RestManager.java
@@ -5,12 +5,12 @@ import pl.zankowski.iextrading4j.api.exception.IEXTradingException;
 import pl.zankowski.iextrading4j.client.IEXCloudToken;
 
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
 import java.util.Map;
 
-import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJsonProvider;
 
 import static java.util.stream.Collectors.joining;
 
@@ -30,20 +30,18 @@ public class RestManager {
         final String url = createURL(restRequest, restClient.getRestClientMetadata().getToken(),
                 restClient.getRestClientMetadata().getUrl());
 
-        final WebTarget target = restClient.getClient().target(url);
+        final Invocation.Builder target = restClient.getClient().target(url).request(MediaType.APPLICATION_JSON);
         Response response = null;
 
         try {
-
             switch (restRequest.getMethodType()) {
                 case GET:
-                    response = target.request(MediaType.APPLICATION_JSON).get();
+                    response = target.get();
                     break;
                 case POST:
                     final PostEntity requestEntity = restRequest.getRequestEntity();
                     requestEntity.setToken(resolveToken(restRequest, restClient.getRestClientMetadata().getToken()));
-                    response = target.register(JacksonJsonProvider.class).request(MediaType.APPLICATION_JSON)
-                              .post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON));
+                    response = target.post(Entity.entity(requestEntity, MediaType.APPLICATION_JSON));
                     break;
                 default:
                     throw new IllegalStateException("Method Type not supported.");


### PR DESCRIPTION
# Description

Correct solution for https://github.com/WojciechZankowski/iextrading4j/pull/82

Assign "JacksonFeature" to rest client for all json mappings. Because without, it conflicts with other libs if they are using other json-providers (for example, Json-B) or other rest-providers (for example, RestEasy).

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
