### PR TITLE
Proposed fix for #96

### DIFF
--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/sse/request/stocks/QuoteSseRequestBuilder.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/sse/request/stocks/QuoteSseRequestBuilder.java
@@ -11,16 +11,22 @@ import java.util.List;
 public class QuoteSseRequestBuilder extends AbstractSymbolSseRequestBuilder<List<Quote>, QuoteSseRequestBuilder> {
 
     private QuoteInterval quoteInterval;
+    private boolean noUTP;
 
     public QuoteSseRequestBuilder withQuoteInterval(final QuoteInterval quoteInterval) {
         this.quoteInterval = quoteInterval;
         return this;
     }
+    
+    public QuoteSseRequestBuilder withNoUTP() {
+    	this.noUTP = true;
+    	return this;
+    }
 
     @Override
     public SseRequest<List<Quote>> build() {
         return SseRequestBuilder.<List<Quote>>builder()
-                .withPath("/stocksUS{interval}")
+                .withPath(noUTP ? "/stocksUSNoUTP{interval}" : "/stocksUS{interval}")
                 .addPathParam("interval", quoteInterval.getName())
                 .withResponse(new GenericType<List<Quote>>() {})
                 .addQueryParam(SYMBOL_PARAM, getSymbol())

--- a/iextrading4j-client/src/test/java/pl/zankowski/iextrading4j/client/sse/request/stocks/QuoteSseRequestBuilderTest.java
+++ b/iextrading4j-client/src/test/java/pl/zankowski/iextrading4j/client/sse/request/stocks/QuoteSseRequestBuilderTest.java
@@ -29,4 +29,21 @@ public class QuoteSseRequestBuilderTest {
         assertThat(request.getQueryParams()).contains(entry("nosnapshot", "false"), entry("symbols", symbol));
     }
 
+    @Test
+    public void shouldSuccessfullyCreateRequestNoUTP() {
+        final String symbol = "IBM";
+
+        final SseRequest<List<Quote>> request = new QuoteSseRequestBuilder()
+                .withQuoteInterval(QuoteInterval.REALTIME)
+                .withSymbol(symbol)
+                .withNoUTP()
+                .build();
+
+        assertThat(request.getPath()).isEqualTo("/stocksUSNoUTP{interval}");
+        assertThat(request.getResponseType()).isEqualTo(new GenericType<List<Quote>>() {
+        });
+        assertThat(request.getPathParams()).contains(entry("interval", ""));
+        assertThat(request.getQueryParams()).contains(entry("nosnapshot", "false"), entry("symbols", symbol));
+    }
+
 }


### PR DESCRIPTION
This is my proposed fix for issue #96, which will allow SSE quotes without a Vendor Agreement. It adds a `QuoteSseRequestBuilder#withNoUTP` method that, when invoked, will have the built `Request` object use the endpoint for non-UTP SSE.