### PR TITLE
Fixed bugs after IEXtrading endpoing 12/01 upgrade (#105)

### DIFF
--- a/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/mapper/HackyLocalDateDeserializer.java
+++ b/iextrading4j-client/src/main/java/pl/zankowski/iextrading4j/client/mapper/HackyLocalDateDeserializer.java
@@ -6,7 +6,10 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 class HackyLocalDateDeserializer extends LocalDateDeserializer {
@@ -31,8 +34,14 @@ class HackyLocalDateDeserializer extends LocalDateDeserializer {
         final String val = parser.getValueAsString();
 
         // #HACK In Daily List they return "0" if data is not available
-        if (val == null || val.equals("0")) {
+        if (val == null || val.equals("0") || val.equals("0000-00-00")) {
             return null;
+        }
+
+        if (val.length() > 10) {
+            LocalDateTime dateTime =
+                    LocalDateTime.ofInstant(Instant.ofEpochMilli(Long.parseLong(val)), ZoneId.systemDefault());
+            return dateTime.toLocalDate();
         }
 
         return super.deserialize(parser, context);

--- a/iextrading4j-client/src/test/java/pl/zankowski/iextrading4j/client/mapper/HackyLocalDateDeserializerTest.java
+++ b/iextrading4j-client/src/test/java/pl/zankowski/iextrading4j/client/mapper/HackyLocalDateDeserializerTest.java
@@ -41,6 +41,18 @@ public class HackyLocalDateDeserializerTest {
     }
 
     @Test
+    public void shouldReturnNullIfValueIsFullOfZeroes() throws IOException {
+        final JsonParser parserMock = mock(JsonParser.class);
+        final DeserializationContext contextMock = mock(DeserializationContext.class);
+
+        when(parserMock.getValueAsString()).thenReturn("0000-00-00");
+
+        final LocalDate result = deserializer.deserialize(parserMock, contextMock);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
     public void shouldReturnNullIfValueIsNull() throws IOException {
         final JsonParser parserMock = mock(JsonParser.class);
         final DeserializationContext contextMock = mock(DeserializationContext.class);

--- a/iextrading4j-test/src/test/java/pl/zankowski/iextrading4j/test/rest/v1/stock/DividendsServiceTest.java
+++ b/iextrading4j-test/src/test/java/pl/zankowski/iextrading4j/test/rest/v1/stock/DividendsServiceTest.java
@@ -45,7 +45,35 @@ public class DividendsServiceTest extends BaseIEXCloudV1ServiceTest {
         assertThat(dividends.getCurrency()).isEqualTo("USD");
         assertThat(dividends.getDescription()).isEqualTo("Apple Hikes Quarterly Dividend 5.5%");
         assertThat(dividends.getFrequency()).isEqualTo("Quarterly");
-        assertThat(dividends.getDate()).isEqualTo(LocalDate.of(2019, 5, 30));
+        assertThat(dividends.getDate()).isEqualTo(LocalDate.of(2019, 11, 19));
+    }
+
+    @Test
+    public void dividendsServiceWithErrorsTest() {
+        stubFor(get(urlEqualTo(path("/stock/AAPL/dividends/1m")))
+                .withHeader("Accept", equalTo("application/json"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Accept", "application/json")
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("rest/v1/stock/DividendsWithErrorsResponse.json")));
+
+        final List<Dividends> dividendsList = cloudClient.executeRequest(new DividendsRequestBuilder()
+                .withDividendRange(DividendRange.ONE_MONTH)
+                .withSymbol("AAPL")
+                .build());
+
+        final Dividends dividends = dividendsList.get(0);
+        assertThat(dividends.getSymbol()).isEqualTo("AAPL");
+        assertThat(dividends.getExDate()).isEqualTo(LocalDate.of(2019, 5, 10));
+        assertThat(dividends.getPaymentDate()).isEqualTo(LocalDate.of(2019, 5, 16));
+        assertThat(dividends.getRecordDate()).isEqualTo(LocalDate.of(2019, 5, 13));
+        assertThat(dividends.getDeclaredDate()).isNull();
+        assertThat(dividends.getAmount()).isEqualTo(BigDecimal.valueOf(0.77));
+        assertThat(dividends.getFlag()).isEqualTo("Increase");
+        assertThat(dividends.getCurrency()).isEqualTo("USD");
+        assertThat(dividends.getDescription()).isEqualTo("Apple Hikes Quarterly Dividend 5.5%");
+        assertThat(dividends.getFrequency()).isEqualTo("Quarterly");
     }
 
 }

--- a/iextrading4j-test/src/test/resources/__files/rest/v1/stock/DividendsWithErrorsResponse.json
+++ b/iextrading4j-test/src/test/resources/__files/rest/v1/stock/DividendsWithErrorsResponse.json
@@ -4,12 +4,13 @@
     "exDate": "2019-05-10",
     "paymentDate": "2019-05-16",
     "recordDate": "2019-05-13",
-    "declaredDate": "2019-04-30",
+    "declaredDate": "0000-00-00",
     "amount": 0.77,
     "flag": "Increase",
     "currency": "USD",
     "description": "Apple Hikes Quarterly Dividend 5.5%",
     "frequency": "Quarterly",
-    "date": "1574121600000"
+    "date": 1455235200000,
+    "updated": 1606190461000
   }
 ]


### PR DESCRIPTION
# Description

The Dec 01 upgrade of IEXCloud enpoints broke many enpoints that started to return some dates as linux epoch values. Also broke some dates that started to appear as 0000-00-00 where previously there were null values.

Fixes # (105)

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ X] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
- [ X] Any dependent changes have been merged and published in downstream modules
