### PR TITLE
Could pl.zankowski:iextrading4j-samples:3.4.4 drop off redundant dependencies to loose weight? 

### DIFF
--- a/iextrading4j-samples/pom.xml
+++ b/iextrading4j-samples/pom.xml
@@ -16,6 +16,36 @@
             <groupId>pl.zankowski</groupId>
             <artifactId>iextrading4j-client</artifactId>
             <version>3.4.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>javax.ws.rs-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>jakarta.inject</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>txw2</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.xml.fastinfoset</groupId>
+                    <artifactId>FastInfoset</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
@WojciechZankowski Hi, I am a user of project **_pl.zankowski:iextrading4j-samples:3.4.4_**. I found that its pom file introduced **_48_** dependencies. However, among them, **_7_** libraries (**_14%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_pl.zankowski:iextrading4j-samples:3.4.4_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.glassfish.hk2.external:jakarta.inject:jar:2.6.1:compile
javax.xml.bind:jaxb-api:jar:2.3.1:compile
org.glassfish.jaxb:txw2:jar:2.3.1:compile
com.sun.xml.fastinfoset:FastInfoset:jar:1.2.15:compile
javax.ws.rs:javax.ws.rs-api:jar:2.1.1:compile
javax.activation:activation:jar:1.1.1:compile
com.sun.xml.bind:jaxb-impl:jar:2.3.1:compile
</code></pre>